### PR TITLE
Add Android Studio 2.2+ CMake

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN mkdir /opt/android-ndk-tmp
 RUN cd /opt/android-ndk-tmp && wget -q https://dl.google.com/android/repository/android-ndk-r13b-linux-x86_64.zip
 # uncompress
 RUN cd /opt/android-ndk-tmp && unzip -q android-ndk-r13b-linux-x86_64.zip
-# move to it's final location
+# move to its final location
 RUN cd /opt/android-ndk-tmp && mv ./android-ndk-r13b ${ANDROID_NDK_HOME}
 # remove temp dir
 RUN rm -rf /opt/android-ndk-tmp
@@ -33,7 +33,7 @@ RUN mkdir /opt/android-cmake-tmp
 RUN cd /opt/android-cmake-tmp && wget -q https://dl.google.com/android/repository/cmake-3.6.3155560-linux-x86_64.zip -O android-cmake.zip
 # uncompress
 RUN cd /opt/android-cmake-tmp && unzip -q android-cmake.zip -d android-cmake
-# move to it's final location
+# move to its final location
 RUN cd /opt/android-cmake-tmp && mv ./android-cmake ${ANDROID_HOME}/cmake
 # remove temp dir
 RUN rm -rf /opt/android-cmake-tmp

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,24 @@ RUN cd /opt/android-ndk-tmp && mv ./android-ndk-r13b ${ANDROID_NDK_HOME}
 RUN rm -rf /opt/android-ndk-tmp
 # add to PATH
 ENV PATH ${PATH}:${ANDROID_NDK_HOME}
+
+
+# ------------------------------------------------------
+# --- Android CMake
+
+# download
+RUN mkdir /opt/android-cmake-tmp
+RUN cd /opt/android-cmake-tmp && wget -q https://dl.google.com/android/repository/cmake-3.6.3155560-linux-x86_64.zip -O android-cmake.zip
+# uncompress
+RUN cd /opt/android-cmake-tmp && unzip -q android-cmake.zip -d android-cmake
+# move to it's final location
+RUN cd /opt/android-cmake-tmp && mv ./android-cmake ${ANDROID_HOME}/cmake
+# remove temp dir
+RUN rm -rf /opt/android-cmake-tmp
+# add to PATH
+ENV PATH ${PATH}:${ANDROID_HOME}/cmake/bin
+
+
 # ------------------------------------------------------
 # --- Cleanup and rev num
 


### PR DESCRIPTION
Since Android Studio 2.2, they're including a CMake dependency in the SDK Manager, but it's not available to install through `android update sdk --no-ui --filter [NAME]` afaik.

The most updated version can be found at: https://dl.google.com/android/repository/repository2-1.xml // last `<remotePackage>` node

This is needed for all new CMake build system: https://developer.android.com/ndk/guides/cmake.html