### PR TITLE
NDK update to r14 added to changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## `v2017_03_21_1`
+
+* `android-ndk-r14-linux-x86_64` - thanks to [koral--](https://github.com/koral--)'s [PR](https://github.com/bitrise-docker/android-ndk/pull/46)
+
 ## `v2016_10_27_1`
 
 * `android-ndk-r13b-linux-x86_64` - thanks to [@mickele](https://github.com/mickele)'s [PR](https://github.com/bitrise-docker/android-ndk/pull/19)


### PR DESCRIPTION
According to https://github.com/bitrise-docker/android-ndk/pull/46#issuecomment-289620708