### PR TITLE
NDK updated to r14b

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## `v2017_03_29_1`
+
+* `android-ndk-r14b-linux-x86_64` - thanks to [koral--](https://github.com/koral--)'s [PR](https://github.com/bitrise-docker/android-ndk/pull/50)
+
+
 ## `v2017_03_21_1`
 
 * `android-ndk-r14-linux-x86_64` - thanks to [koral--](https://github.com/koral--)'s [PR](https://github.com/bitrise-docker/android-ndk/pull/46)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM bitriseio/docker-android-alpha:latest
 
 ENV ANDROID_NDK_HOME /opt/android-ndk
+ENV ANDROID_NDK_VERSION r14b
 
 
 # ------------------------------------------------------
@@ -14,11 +15,11 @@ RUN apt-get update -qq
 
 # download
 RUN mkdir /opt/android-ndk-tmp
-RUN cd /opt/android-ndk-tmp && wget -q https://dl.google.com/android/repository/android-ndk-r14-linux-x86_64.zip
+RUN cd /opt/android-ndk-tmp && wget -q https://dl.google.com/android/repository/android-ndk-${ANDROID_NDK_VERSION}-linux-x86_64.zip
 # uncompress
-RUN cd /opt/android-ndk-tmp && unzip -q android-ndk-r14-linux-x86_64.zip
+RUN cd /opt/android-ndk-tmp && unzip -q android-ndk-${ANDROID_NDK_VERSION}-linux-x86_64.zip
 # move to its final location
-RUN cd /opt/android-ndk-tmp && mv ./android-ndk-r14 ${ANDROID_NDK_HOME}
+RUN cd /opt/android-ndk-tmp && mv ./android-ndk-${ANDROID_NDK_VERSION} ${ANDROID_NDK_HOME}
 # remove temp dir
 RUN rm -rf /opt/android-ndk-tmp
 # add to PATH
@@ -31,5 +32,6 @@ ENV PATH ${PATH}:${ANDROID_NDK_HOME}
 # Cleaning
 RUN apt-get clean
 
-ENV BITRISE_DOCKER_REV_NUMBER_ANDROID_NDK v2017_03_21_1
+ENV BITRISE_DOCKER_REV_NUMBER_ANDROID_NDK v2017_03_29_1
 CMD bitrise -version
+


### PR DESCRIPTION
Changelog is also updated.
PS `sdkmanager` from SDK tools 25+ can also install NDK, but there is no way to specify exact version:
```sdkmanager --list |grep -C 1 -m 1 ndk
  lldb;2.3                          | 2.3.3614996  | LLDB 2.3                          | lldb/2.3/                        
  ndk-bundle                        | 14.1.3816874 | NDK                               | ndk-bundle/                      
  patcher;v1                        | 1            | SDK Patch Applier v1              | patcher/v1/   
```
There is no version number part (after semicolon) and the latest one from given channel (stable by default) is picked.
If it is acceptable to have dynamic version here I can send a new PR.