### PR TITLE
NDK installation using temporary directory changed to piped decompression with `bsdtar`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## `v2017_04_18_1`
+
+* NDK installation using temporary directory changed to piped decompression with `bsdtar` - thanks to [koral--](https://github.com/koral--)'s [PR](https://github.com/bitrise-docker/android-ndk/pull/55)
+
 ## `v2017_03_29_1`
 
 * `android-ndk-r14b-linux-x86_64` - thanks to [koral--](https://github.com/koral--)'s [PR](https://github.com/bitrise-docker/android-ndk/pull/50)

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,23 +8,19 @@ ENV ANDROID_NDK_VERSION r14b
 # --- Install required tools
 
 RUN apt-get update -qq && \
+    apt-get install -y bsdtar && \
     apt-get clean
 
 
 # ------------------------------------------------------
 # --- Android NDK
 
+# create destination directory
+RUN mkdir ${ANDROID_NDK_HOME} && \
 # download
-RUN mkdir /opt/android-ndk-tmp && \
-    cd /opt/android-ndk-tmp && \
-    wget -q https://dl.google.com/android/repository/android-ndk-${ANDROID_NDK_VERSION}-linux-x86_64.zip && \
-# uncompress
-    unzip -q android-ndk-${ANDROID_NDK_VERSION}-linux-x86_64.zip && \
-# move to its final location
-    mv ./android-ndk-${ANDROID_NDK_VERSION} ${ANDROID_NDK_HOME} && \
-# remove temp dir
-    cd ${ANDROID_NDK_HOME} && \
-    rm -rf /opt/android-ndk-tmp
+    wget -qO- https://dl.google.com/android/repository/android-ndk-${ANDROID_NDK_VERSION}-linux-x86_64.zip | \
+# uncompress to its final location
+    bsdtar -xf- -C $ANDROID_NDK_HOME -s /^android-ndk-${ANDROID_NDK_VERSION}//
 
 # add to PATH
 ENV PATH ${PATH}:${ANDROID_NDK_HOME}
@@ -33,6 +29,6 @@ ENV PATH ${PATH}:${ANDROID_NDK_HOME}
 # ------------------------------------------------------
 # --- Cleanup and rev num
 
-ENV BITRISE_DOCKER_REV_NUMBER_ANDROID_NDK v2017_03_29_1
+ENV BITRISE_DOCKER_REV_NUMBER_ANDROID_NDK v2017_04_18_1
 CMD bitrise -version
 

--- a/system_report.sh
+++ b/system_report.sh
@@ -37,3 +37,4 @@ echo "=== Pre-installed tool versions ========"
 # ver_line="$(cmake --version | head -n 1)" ;         echo "* cmake: $ver_line"
 echo "========================================"
 echo
+ver_line="$(bsdtar --version | head -n 1)" ;         echo "* bsdtar: $ver_line"


### PR DESCRIPTION
It should save some time and container disc space (~800 MB in case of NDK r14b) required when building an image.